### PR TITLE
fix(test/defs.h): Include stat.h when the system is running Linux wit…

### DIFF
--- a/test/defs.h
+++ b/test/defs.h
@@ -14,6 +14,10 @@
 #include <wchar.h>
 #include <unistd.h>
 
+#if !defined(__GLIBC__) && defined(__linux__)
+#include <sys/stat.h>
+#endif
+
 #if defined (__GLIBC__) && defined (_IO_getc_unlocked)
 #undef	putchar
 #define	putchar(c)	_IO_putc_unlocked(c, stdout)


### PR DESCRIPTION
…hout the GNU C Library.

This adds a declaration of the type mode_t and fixes the error "defs.h:53:38: error: unknown type name ‘mode_t’".