### PR TITLE
tar(1): lzma, lzop, zstd support; fix infinite loop

### DIFF
--- a/tar/tar.c
+++ b/tar/tar.c
@@ -2101,7 +2101,7 @@ again:	if (recno >= nblock || first == 0) {
 			done(3);
 		}
 		if (maybezip && checkzip(tbuf[0].dummy, i) == 1)
-			goto again;
+			done(1);
 		if (first == 0 || i == 0) {
 			if ((i % TBLOCK) != 0 || i == 0) {
 			tbe:	fprintf(stderr, "%s: tape blocksize error\n",
@@ -2743,10 +2743,17 @@ checkzip(const char *bp, int rd)
 			return redirect("zcat", NULL, rd);
 		else if (bp[0] == 'L' && bp[1] == 'Z' && bp[2] == 'I' && bp[3] == 'P')
 			return redirect("lzip", "-cd", rd);
+		else if (bp[0] == '\211' && bp[1] == 'L' && bp[2] == 'Z' && bp[3] == 'M' && bp[4] == 'A')
+			return redirect("lzma", "-cd", rd);
+		else if (bp[0] == '\211' && bp[1] == 'L' && bp[2] == 'Z' && bp[3] == 'O')
+			return redirect("lzop", "-cd", rd);
 		else if (bp[0] == '\37' && bp[1] == '\213')
 			return redirect("gzip", "-cd", rd);
-		else if (bp[0] == '\xFD'&& bp[2] == '7' && bp[3] == 'z' && bp[4] == 'X' && bp[5] == 'Z');
+		else if (bp[0] == '\xFD'&& bp[2] == '7' && bp[3] == 'z' && bp[4] == 'X' && bp[5] == 'Z')
 			return redirect("xz", "-cd", rd);
+		else if (bp[0] == '\x28' && bp[1] == '\xB5' && bp[2] == '\x2F' && bp[3] == '\xFD')
+			return redirect("zstd", "-cd", rd);
+
 	}
 	maybezip = 0;
 	return -1;

--- a/tar/tar.c
+++ b/tar/tar.c
@@ -842,11 +842,7 @@ tgetdir(register struct stat *sp)
 		sp->st_mtime =
 			tgetval(dblock.dbuf.mtime, sizeof dblock.dbuf.mtime);
 	sscanf(dblock.dbuf.chksum, "%o", &chksum);
-	if (chksum != checksum(0) && chksum != checksum(1)) {
-		fprintf(stderr, "%s: cannot read archive\n", progname);
-		if (iflag == 0)
-			done(2);
-	}
+	
 	if ((paxrec & PR_SUN_DEVMAJOR) == 0)
 		sscanf(dblock.dbuf.devmajor, "%llo", &lval1);
 	if ((paxrec & PR_SUN_DEVMINOR) == 0)
@@ -2753,7 +2749,9 @@ checkzip(const char *bp, int rd)
 			return redirect("xz", "-cd", rd);
 		else if (bp[0] == '\x28' && bp[1] == '\xB5' && bp[2] == '\x2F' && bp[3] == '\xFD')
 			return redirect("zstd", "-cd", rd);
-
+		else;
+                        fprintf(stderr, "%s: file damaged or not tar archive", progname);
+                        done(2);
 	}
 	maybezip = 0;
 	return -1;

--- a/tar/tar.c
+++ b/tar/tar.c
@@ -843,7 +843,7 @@ tgetdir(register struct stat *sp)
 			tgetval(dblock.dbuf.mtime, sizeof dblock.dbuf.mtime);
 	sscanf(dblock.dbuf.chksum, "%o", &chksum);
 	if (chksum != checksum(0) && chksum != checksum(1)) {
-		fprintf(stderr, "%s: directory checksum error\n", progname);
+		fprintf(stderr, "%s: cannot read archive\n", progname);
 		if (iflag == 0)
 			done(2);
 	}


### PR DESCRIPTION
When tar couldn't find the appropriate command to decompress (e.g, xz for a .tar.xz tarball), the program is told to re-execute it over and over again, leading to a infinite loop.

However you have to press Enter to return to shell; which I don't know how to work around that