### PR TITLE
Fix getdirentries on OpenBSD >5.4

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -2,7 +2,7 @@ Copyright (c) 2003-2007 Gunnar Ritter et al.
 Copyright (c) 2021-2022 Pindorama
 			Luiz Antônio Rangel (takusuman)
 			Arthur Bacci (arthurbacci)
-Copyright (c) 2022 Molly A. McCollum (hex7c)
+Copyright (c) 2022 Molly A. McCollum (mamccollum)
 
 This software is provided 'as-is', without any express or implied
 warranty.  In no event will the authors be held liable for any damages

--- a/libcommon/getdir.c
+++ b/libcommon/getdir.c
@@ -21,21 +21,26 @@
 #include	<string.h>
 
 /*
- * TODO: Write a boilerplate for getdirentries() that uses opendir() and
- * readdir(). Needed for OpenBSD releases greater than 5.4 --- maybe other
- * systems nowadays --- since getdirentries() got deprecated there.
- * The sketch below shall work as a guide for writing it.
- * 
+ * boilerplate for getdirentries(). Needed for OpenBSD releases greater than 5.4.
+ */
 #if  defined(__OpenBSD__)
 #include <sys/param.h>
+#include <dirent.h>
 #if OpenBSD >= 201311
 int
 getdirentries(int fd, char buf[], int nbytes, long basep[]) {
-
+	/* See: 
+	 * 		https://man7.org/linux/man-pages/man3/getdirentries.3.html
+	 *		https://git.suckless.org/9base/file/lib9/dirread.c.html
+	 *		https://man.openbsd.org/getdents.2
+	 *		Above are docs for solutions chosen.
+	 */
+	
+	return getdents(fd, (void*)buf, nbytes);
 }
 #endif
 #endif
-*/
+
 
 #if defined (__UCLIBC__)
 #include <linux/types.h>


### PR DESCRIPTION
`getdirentries` was broken after OpenBSD 5.4; this PR fixes issue #16 and compiles and works on programs like `du`. Note that other changes are required outside of the scope of this pull request to ensure the entire project builds under OpenBSD.

New issues were discovered after fixing this one; T\this includes libcrypt not being found on OpenBSD for the `su` program, `whodo` not compiling, and `pgrep` and `ps` not compiling due to KVM function errors (kernel virtual memory? looks to be something to do with libkvm).

Please let me know if any other changes are required on this request, this should not break or modify the build process on any other systems.